### PR TITLE
Forced forward cascade

### DIFF
--- a/zpgenerator/network/element.py
+++ b/zpgenerator/network/element.py
@@ -4,6 +4,7 @@ from ..system import AElement, AScatteringMatrix, AQuantumSystem, AQuantumEmitte
 from typing import List, Union
 from math import prod
 from qutip import tensor, Qobj
+from itertools import chain
 
 
 class ElementCollection(AElement, TimeOperatorCollection):
@@ -129,12 +130,15 @@ class ElementCollection(AElement, TimeOperatorCollection):
                    if not isinstance(element, AScatteringMatrix) else
                    element.is_time_dependent(t, parameters) for element in self._elements)
 
-    def evaluate_quadruple(self, t: float, parameters: dict = None):
-        parameters = self.set_parameters(parameters)
+    def evaluate_quadruple(self, t: float, parameters: dict = None) -> EvaluatedQuadruple:
         if self._elements:
-            return self._rule([element.evaluate_quadruple(t, parameters) for element in self._elements])
+            return self._rule(self.gather_quadruples(t, parameters))
         else:
             return EvaluatedQuadruple()
+
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        parameters = self.set_parameters(parameters)
+        return list(chain(*[element.gather_quadruples(t, parameters) for element in self._elements]))
 
     def evaluate_dirac(self, t: float, parameters: dict = None) -> EvaluatedDiracOperator:
         parameters = self.set_parameters(parameters)

--- a/zpgenerator/system/emitter.py
+++ b/zpgenerator/system/emitter.py
@@ -139,3 +139,6 @@ class EmitterBase(AQuantumEmitter, ControlledSystem):
         super()._add(system, parameters, name)
         if isinstance(system, LindbladVector):
             self.transitions.add(system, parameters, name)
+
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        return [self.evaluate_quadruple(t, parameters)]

--- a/zpgenerator/system/multibody.py
+++ b/zpgenerator/system/multibody.py
@@ -116,10 +116,14 @@ class MultiBodyEmitterBase(AQuantumMultiBodyEmitter, SystemCollection):
         return self._rule([system.evaluate_quadruple(t, parameters) for system in self._subsystems],
                           EvaluatedQuadruple())
 
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        return [self.evaluate_quadruple(t, parameters)]
+
     def evaluate_dirac(self, t: float, parameters: dict = None) -> EvaluatedDiracOperator:
         parameters = self.set_parameters(parameters)
         return self._rule(id_flatten([op.evaluate_dirac(t, parameters) for op in self._subsystems]),
                           EvaluatedDiracOperator())
+
 
 class MultiBodyEmitter(MultiBodyEmitterBase):
     """

--- a/zpgenerator/system/scatterer.py
+++ b/zpgenerator/system/scatterer.py
@@ -4,6 +4,7 @@ from ..time.evaluate.quadruple import EvaluatedQuadruple
 from abc import abstractmethod
 from qutip import rand_unitary_haar
 from math import prod
+from typing import List
 
 
 class AElement(ATimeOperator):
@@ -27,6 +28,10 @@ class AElement(ATimeOperator):
     @property
     @abstractmethod
     def is_emitter(self) -> bool:
+        pass
+
+    @abstractmethod
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
         pass
 
     @abstractmethod
@@ -70,6 +75,9 @@ class ScattererBase(AScatteringMatrix, CompositeTimeOperator):
             transitions=[EvaluatedOperator()] * self.modes,
             scatterer=self.partial_evaluate(t, parameters))
 
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        return [self.evaluate_quadruple(t, parameters)]
+
     @classmethod
     def haar_random(cls, n: int):
         return cls(TimeOperator(rand_unitary_haar(n)))
@@ -100,6 +108,9 @@ class MultiScatterer(AScatteringMatrix, TimeOperatorCollection):
             transitions=[EvaluatedOperator()] * self.modes,
             scatterer=self.partial_evaluate(t, parameters))
 
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        return [self.evaluate_quadruple(t, parameters)]
+
     @classmethod
     def haar_random(cls, n: int):
         return cls(TimeOperator(rand_unitary_haar(n)))
@@ -128,6 +139,9 @@ class CompositeScatterer(AScatteringMatrix, TimeOperatorCollection):
         return EvaluatedQuadruple(
             transitions=[EvaluatedOperator()] * self.modes,
             scatterer=self.partial_evaluate(t, parameters))
+
+    def gather_quadruples(self, t: float, parameters: dict = None) -> List[EvaluatedQuadruple]:
+        return [self.evaluate_quadruple(t, parameters)]
 
     @classmethod
     def haar_random(cls, n: int):


### PR DESCRIPTION
Forced a forward evaluation ordering for cascaded interaction due to non-commuting correlated dissipation for non-unitary circuits. Fixed errors when applying non-unitary scattering matrices to subcomponents of a cascaded system.